### PR TITLE
feat: Allow singleton directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ telescope.setup({
         whaler = {
             -- Whaler configuration
             directories = { "path/to/dir", "path/to/another/dir" },
-            -- You may also add directories that will not be search for subdirectories
-            singleton_directories = { "path/to/project/folder" },
+            -- You may also add directories that will not be searched for subdirectories
+            oneoff_directories = { "path/to/project/folder" },
         }
     }
 })

--- a/README.md
+++ b/README.md
@@ -64,8 +64,9 @@ telescope.setup({
     extensions = {
         whaler = {
             -- Whaler configuration
-            -- You may prefix a path with `=` to add a singleton project directory
-            directories = { "path/to/dir", "path/to/another/dir", "=path/to/project/folder" },
+            directories = { "path/to/dir", "path/to/another/dir" },
+            -- You may also add directories that will not be search for subdirectories
+            singleton_directories = { "path/to/project/folder" },
         }
     }
 })

--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ telescope.setup({
     extensions = {
         whaler = {
             -- Whaler configuration
-            directories = { "path/to/dir", "path/to/another/dir" },
+            -- You may prefix a path with `=` to add a singleton project directory
+            directories = { "path/to/dir", "path/to/another/dir", "=path/to/project/folder" },
         }
     }
 })

--- a/doc/whaler.txt
+++ b/doc/whaler.txt
@@ -93,7 +93,9 @@ Here is the list of a default configuration:
 
 ```lua
 whaler = {
-    directories = { "/home/user/projects", "/home/user/work"}, -- Absolute path directories to search. By default the list is empty.
+    -- Absolute path directories to search. By default the list is empty. A folder path may be
+    -- prefixed with a `=` to add a single directory instead of searching it for subdirectories.
+    directories = { "/home/user/projects", "/home/user/work", "=/path/to/single/folder"}, 
     auto_file_explorer = true, -- Whether to automatically open file explorer. By default is `true`
     auto_cwd = true, -- Whether to automatically change current working directory. By default is `true`
     file_explorer = "netrw", -- Automagically creates a configuration for the file explorer of your choice. 

--- a/doc/whaler.txt
+++ b/doc/whaler.txt
@@ -94,9 +94,9 @@ Here is the list of a default configuration:
 ```lua
 whaler = {
     -- Absolute path directories to search. By default the list is empty. A folder path may be
-    directories = { "/home/user/projects", "/home/user/work", "=/path/to/single/folder"}, 
-    -- You may also add directories that will not be search for subdirectories
-    singleton_directories = { "/home/user/path/to/project" },
+    directories = { "/home/user/projects", "/home/user/work" }, 
+    -- You may also add directories that will not be searched for subdirectories
+    oneoff_directories = { "/home/user/path/to/project" },
 
     auto_file_explorer = true, -- Whether to automatically open file explorer. By default is `true`
     auto_cwd = true, -- Whether to automatically change current working directory. By default is `true`

--- a/doc/whaler.txt
+++ b/doc/whaler.txt
@@ -94,8 +94,10 @@ Here is the list of a default configuration:
 ```lua
 whaler = {
     -- Absolute path directories to search. By default the list is empty. A folder path may be
-    -- prefixed with a `=` to add a single directory instead of searching it for subdirectories.
     directories = { "/home/user/projects", "/home/user/work", "=/path/to/single/folder"}, 
+    -- You may also add directories that will not be search for subdirectories
+    singleton_directories = { "/home/user/path/to/project" },
+
     auto_file_explorer = true, -- Whether to automatically open file explorer. By default is `true`
     auto_cwd = true, -- Whether to automatically change current working directory. By default is `true`
     file_explorer = "netrw", -- Automagically creates a configuration for the file explorer of your choice. 

--- a/lua/telescope/_extensions/whaler/main.lua
+++ b/lua/telescope/_extensions/whaler/main.lua
@@ -59,7 +59,7 @@ M.get_subdir = function(dir)
     local tbl_dir = {}
 
     if is_singleton_dir  then
-        tbl_dir[dir:sub(1)] = dir:sub(1)
+        tbl_dir[dir] = dir
     else
         for _,v in pairs(_fn.readdir(dir)) do
             local entry = dir .. "/" .. v

--- a/lua/telescope/_extensions/whaler/main.lua
+++ b/lua/telescope/_extensions/whaler/main.lua
@@ -46,6 +46,10 @@ local theme_opts  = { -- Theme Options table
 M.get_subdir = function(dir)
     -- Get all subdirectories from a directory
     dir = dir or {}
+    local is_singleton_dir = string.sub(dir, 1, 1) == "="
+    if is_singleton_dir then
+        dir = dir:sub(2)
+    end
 
     if _fn.isdirectory(dir) == 0 then
         log.warn("Directory "..dir.. " is not a valid directory")
@@ -54,11 +58,15 @@ M.get_subdir = function(dir)
 
     local tbl_dir = {}
 
-    for _,v in pairs(_fn.readdir(dir)) do
-        local entry = dir .. "/" .. v
-        if _fn.isdirectory(entry) == 1 then
-            local parsed_dir = _utils.parse_directory(entry)
-            tbl_dir[parsed_dir] = parsed_dir
+    if is_singleton_dir  then
+        tbl_dir[dir:sub(1)] = dir:sub(1)
+    else
+        for _,v in pairs(_fn.readdir(dir)) do
+            local entry = dir .. "/" .. v
+            if _fn.isdirectory(entry) == 1 then
+                local parsed_dir = _utils.parse_directory(entry)
+                tbl_dir[parsed_dir] = parsed_dir
+            end
         end
     end
 

--- a/lua/telescope/_extensions/whaler/main.lua
+++ b/lua/telescope/_extensions/whaler/main.lua
@@ -21,7 +21,7 @@ local M = {}
 
 -- Whaler variables (on setup)
 local directories -- Absolute path directories to search in (default {}) (map)
-local singletong_directories -- Absolute path to singleton directories
+local oneoff_directories -- Absolute path to oneoff directories
 local auto_file_explorer -- Whether to automatically open file explorer  (default true) (boolean)
 local auto_cwd -- Whether to automatically change working directory (default true) (boolean)
 local file_explorer -- Which file explorer to open (netrw, nvim-tree, neo-tree)
@@ -96,9 +96,9 @@ M.dirs = function()
     local hd = directories or {}
     local subdirs = M.get_entries(hd) or {}
 
-    -- Merge the singleton directories
-    for _, singleton in ipairs(singleton_directories)do
-        subdirs[singleton] = singleton
+    -- Merge the oneoff directories
+    for _, oneoff in ipairs(oneoff_directories)do
+        subdirs[oneoff] = oneoff
     end
 
     return subdirs
@@ -150,7 +150,7 @@ M.setup = function(setup_config)
     end
 
     directories = setup_config.directories or {} -- No directories by default
-    singleton_directories = setup_config.singleton_directories or {} -- No directories by default
+    oneoff_directories = setup_config.oneoff_directories or {} -- No directories by default
 
     -- Open file explorer is true by default
     if setup_config.auto_file_explorer == nil then


### PR DESCRIPTION
I often have single projects laying around and I want to add them to the list too. Currently whaler will always search for subdirectories. This PR makes it possible to add singleton directories by prefixing the path with an `=`. This is a similar mechanism to the one used by other neovim project plugins and originated AFAIK on `airblade/vim-rooter`.