### PR TITLE
Allow directory aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ It is based on the concept of [tmux-windowizer](https://github.com/ThePrimeagen/
 
 ![whaler-example](whaler-example.gif)
 
-`Whaler.nvin` does primarly the following things:
+`Whaler.nvin` does primarily the following things:
 1. Looks for subdirectories in a set of directories passed as arguments.
 2. Fuzzy finds among the subdirectories.
 3. Once a directory is selected it automatically changes the vim `cwd` to the selected directory. (customizable)

--- a/README.md
+++ b/README.md
@@ -86,6 +86,12 @@ vim.keymap.set("n", "<leader>fw", function()
 vim.keymap.set("n", "<leader>fw", telescope.extensions.whaler.whaler)
 ```
 
+In addition to passing strings into the `directories` and `oneoff_directories`
+parameters above one may also choose to use tables such as
+`{path="/path/to/dir", alias="Personal Projects"}`, this will modify the text
+presented in the selection UI to show `[Personal Projects] theproject` instead
+of the full path to each of the project folders.
+
 Now, pressing `<leader>fw` will open a Telescope picker with the subdirectories of the specified directories for you to select.
 
 ## Customization

--- a/doc/whaler.txt
+++ b/doc/whaler.txt
@@ -85,6 +85,12 @@ vim.keymap.set("n", "<leader>fw", telescope.extensions.whaler.whaler)
 
 ```
 
+In addition to passing strings into the `directories` and `oneoff_directories`
+parameters above one may also choose to use tables such as
+`{path="/path/to/dir", alias="Personal Projects"}`, this will modify the text
+presented in the selection UI to show `[Personal Projects] theproject` instead
+of the full path to each of the project folders.
+
 ==============================================================================
  4. CUSTOMIZATION                                     *whaler-customization*
 

--- a/lua/telescope/_extensions/whaler/main.lua
+++ b/lua/telescope/_extensions/whaler/main.lua
@@ -110,8 +110,9 @@ M.dirs = function()
 
     -- merge oneoff into subdirs
     for _, oneoff in ipairs(oneoff_dirs) do
-        local parsed_oneoff = _utils.parse_directory(oneoff) -- Remove any / at the end.
-        subdirs[#subdirs+1] = parsed_oneoff
+        local parsed_oneoff = _utils.parse_directory(oneoff.path) -- Remove any / at the end.
+        oneoff.path = parsed_oneoff
+        subdirs[#subdirs+1] = oneoff
     end
 
     return subdirs


### PR DESCRIPTION
This PR builds on top of #8 and adds the option to choose an alias to replace the path on the Telescope UI. Before this PR (but after PR #8) a typical configuration could look like:

```lua
whaler = {
  directories = {
    "/Users/guillem/projects",
    "=/Users/guillem/Documents/personal_repos/zero2prod",
  },
}
```
and the resulting whaler prompt would be:
<img width="548" alt="image" src="https://github.com/SalOrak/whaler.nvim/assets/6859287/370f7df0-676f-4d5a-97d2-9d5693e77d8f">

Here we implement the option to pass a table instead of just a string that contains:
1.  A `path`, the same as would've been the string path before
2. An `alias` that will replace the path to the folder

A config could look like:

```lua
whaler = {
  directories = {
    { path = "/Users/guillem/projects", alias = "plugins" },
    "=/Users/guillem/Documents/personal_repos/zero2prod",
  },
}
```

and in this case the output would be:

<img width="566" alt="image" src="https://github.com/SalOrak/whaler.nvim/assets/6859287/884a7765-ddaf-48f1-9f4d-ed6055cf219d">

Note: This PR is still incomplete as it is _at least_ missing documentation but I thought I'd wait until you  decide if you are interested on merging.