### PR TITLE
Independent whaler run

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ telescope.load_extension("whaler")
 vim.keymap.set("n", "<leader>fw", function()
     local w = telescope.extensions.whaler.whaler
     w({
-        -- Settings can also be called here
+        -- Settings can also be called here.
+        -- These would use but not change the setup configuration.
     })
  end,)
 
@@ -166,6 +167,55 @@ whaler = {
 ```
 Imaging you are starting a new project called **harp** inside your work path (`"/home/user/work"`). This new project it is similar to another already developed project called **Wheel** but with some fundamental changes. You want to compare the starting files side by side. You can enter the **harp** project and open the starting file. Then execute `Whaler.nvim` with the previous configuration setup and select the **Wheel** project. Notice that nothing really changed. But if you now find files in the current directory using `Telescope find_files` it would display ALL the **Wheel** files available. You can then open the desired file in a vertical split (default to `<C-v>` ) and keep modifying the main file in the **harp** project having the developed main **Wheel** side by side.
 
+
+#### Multiple Whaler use cases
+
+Let's say you want to search for a file in another directory but don't want to change directories again. Whaler can multiple configuration directly. 
+The setup dictates the defaults of how Whaler would behave if nothing is passed when executed.
+```lua
+-- Setup whaler
+whaler = {
+    directories = { "/home/user/projects", { path = "/home/user/work", alias = "work" } },
+    oneoff_directories = { "/home/user/.config/nvim" }, 
+    auto_file_explorer = true, 
+    auto_cwd = true, 
+    file_explorer = "netrw",
+    theme = {                -- Telescope theme default Whaler options.
+        results_title = false,
+        layout_strategy = "center",
+        previewer = false,
+        layout_config = {
+            height =  0.3,
+            width = 0.4
+        },
+        sorting_strategy = "ascending",
+        border = true,
+    } 
+}
+```
+
+Now, we configure the keymaps and add a new keymap to run Whaler and instead of changing directories it will run `Telescope find_file`.
+```lua
+local keymap = vim.keymap
+keymap.set("n", "<leader>ww", telescope.extensions.whaler.whaler)
+keymap.set("n", "<leader>wn", function()
+        local w = telescope.extensions.whaler.whaler
+        w({
+            auto_file_explorer = true,
+            auto_cwd = false,
+            file_explorer_config = {
+            plugin_name = "telescope",
+            command = "Telescope find_files",
+            prefix_dir = " cwd=",
+            },
+            theme = {
+            previewer = false,
+            },
+            })
+        end)
+        
+```
+Pressing `<leader>ww` would run Whaler with the setup previously configured, running netrw and changing directories. On the other hand, pressing `<leader>wn` would run Whaler with the new configuration, without changing directories and running `Telescope find_files` in the selected directory.
 
 ## Supported File Explorers
 

--- a/lua/telescope/_extensions/whaler/main.lua
+++ b/lua/telescope/_extensions/whaler/main.lua
@@ -20,26 +20,30 @@ local _filex = require("telescope._extensions.whaler.file_explorer")
 local M = {}
 
 -- Whaler variables (on setup)
-local directories -- Absolute path directories to search in (default {}) (map)
-local oneoff_directories -- Absolute path to oneoff directories
-local auto_file_explorer -- Whether to automatically open file explorer  (default true) (boolean)
-local auto_cwd -- Whether to automatically change working directory (default true) (boolean)
-local file_explorer -- Which file explorer to open (netrw, nvim-tree, neo-tree)
-local file_explorer_config -- Map to configure the map explorer Keys: { plugin-name, command_to_toggle }  -- Does NOT accept netrw
+local config = {
+    directories = {}, -- Absolute path directories to search in (default {}) (map)
+    oneoff_directories = {}, -- Absolute path to oneoff directories
+    auto_file_explorer = true, -- Whether to automatically open file explorer  (default true) (boolean)
+    auto_cwd = true, -- Whether to automatically change working directory (default true) (boolean)
+    file_explorer = "netrw", -- Which file explorer to open (netrw, nvim-tree, neo-tree)
+    file_explorer_config = {}, -- Map to configure the map explorer Keys: { plugin-name, command_to_toggle } , -- Does NOT accept netrw
 
--- Telescope variables
-local theme_opts  = { -- Theme Options table
-    results_title = false,
-    layout_strategy = "center",
-    previewer = false,
-    layout_config = {
-        --preview_cutoff = 1000,
-        height =  0.3,
-        width = 0.4
-    },
-    sorting_strategy = "ascending",
-    border = true,
+    -- Telescope variables
+    -- Theme Options table
+    theme_opts = {
+        results_title = false,
+        layout_strategy = "center",
+        previewer = false,
+        layout_config = {
+            --preview_cutoff = 1000,
+            height =  0.3,
+            width = 0.4
+        },
+        sorting_strategy = "ascending",
+        border = true,
+    }
 }
+
 
 
 -- Whaler Main functions ---
@@ -101,7 +105,7 @@ M.get_entries = function(tbl_dir, find_subdirectories)
     return tbl_entries
 end
 
-M.dirs = function()
+M.dirs = function(directories, oneoff_directories)
     local hd = directories or {}
     local oneoff_hd = oneoff_directories or {}
 
@@ -118,10 +122,11 @@ M.dirs = function()
     return subdirs
 end
 
-M.whaler = function(opts)
-    opts = vim.tbl_deep_extend("force", theme_opts, opts or {})
+M.whaler = function(conf)
+    local run_config = vim.tbl_deep_extend("force", config, conf or {})
+    local opts = run_config.theme_opts or {}
 
-    local dirs = M.dirs() or {}
+    local dirs = M.dirs(run_config.directories, run_config.oneoff_directories) or {}
 
     local format_entry = function(entry)
         if entry.alias then
@@ -152,13 +157,17 @@ M.whaler = function(opts)
                 local selection = _action_state.get_selected_entry()
                 if selection then
                     -- Change current directory
-                    if auto_cwd then
+                    if run_config.auto_cwd then
                         vim.api.nvim_set_current_dir(selection.path)
                     end
 
-                    if auto_file_explorer then
+                    if run_config.auto_file_explorer then
                         -- Command to open netrw
-                        local cmd = vim.api.nvim_parse_cmd(file_explorer_config["command"] .. file_explorer_config["prefix_dir"].. selection.path,{})
+                        local cmd = vim.api.nvim_parse_cmd(
+                                        run_config.file_explorer_config["command"]
+                                        .. run_config.file_explorer_config["prefix_dir"]
+                                        .. selection.path,{}
+                                        )
                         -- Execute command
                         vim.api.nvim_cmd(cmd, {})
                     end
@@ -173,32 +182,28 @@ M.setup = function(setup_config)
 
     if setup_config.theme and setup_config.theme ~= "" then
         -- theme_opts = _themes["get_" .. setup_config.theme]()
-        theme_opts = vim.tbl_deep_extend("force", theme_opts, setup_config.theme or {})
+        config = vim.tbl_deep_extend("force", config, setup_config or {})
     end
 
-    directories = setup_config.directories or {} -- No directories by default
-    oneoff_directories = setup_config.oneoff_directories or {} -- No directories by default
+    config.directories = setup_config.directories or {} -- No directories by default
+    config.oneoff_directories = setup_config.oneoff_directories or {} -- No directories by default
 
     -- Open file explorer is true by default
-    if setup_config.auto_file_explorer == nil then
-        auto_file_explorer = true
-    else
-        auto_file_explorer = setup_config.auto_file_explorer
+    if setup_config.auto_file_explorer ~= nil then
+        config.auto_file_explorer = setup_config.auto_file_explorer
     end
 
     -- Change directory is true by default
-    if setup_config.auto_cwd == nil then
-        auto_cwd = true
-    else
-        auto_cwd = setup_config.auto_cwd
+    if setup_config.auto_cwd ~= nil then
+        config.auto_cwd = setup_config.auto_cwd
     end
 
-    file_explorer = setup_config.file_explorer or "netrw" -- netrw by default
-    file_explorer_config = setup_config.file_explorer_config or _filex.create_config(file_explorer)
+    config.file_explorer = setup_config.file_explorer or "netrw" -- netrw by default
+    config.file_explorer_config = setup_config.file_explorer_config or _filex.create_config(config.file_explorer)
 
     -- If file_explorer_config is not valid use netrw as fallback
-    if not _filex.check_config(file_explorer_config) then
-        file_explorer_config = _filex.create_config("netrw")
+    if not _filex.check_config(config.file_explorer_config) then
+        config.file_explorer_config = _filex.create_config("netrw")
     end
 
 end


### PR DESCRIPTION
### Description

Currently it only allows whaler to be run with one configuration.
For example, if you set auto_cwd on the setup, currently, there is no way to run Whaler without changing any directories.

###Type of change

Would be a breaking change because the current state of the plugin allows theme_opts and it should allow opts.

### Issues 
#13 