### PR TITLE
Add support for `rnvimr` plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ Currently the following file explorers are supported out of the box:
 - [Oil](https://github.com/stevearc/oil.nvim). Does not require any configuration.
 - [Nvim-Tree](https://github.com/nvim-tree/nvim-tree.lua). To work as intended add `sync_root_with_cwd = true` in the `nvim-tree` setup function.
 - [Telescope-file-browser](https://github.com/nvim-telescope/telescope-file-browser.nvim). Does not require any configuration.
-- [rnvimr](https://github.com/kevinhwang91/rnvimr). To work as intended add the following code to the `rnvimr` settings file and include the `file_explorer = "rnvimr"` in the `whaler` setup function.
+- [rnvimr](https://github.com/kevinhwang91/rnvimr). To work as intended add the following code to the `rnvimr` settings file and add the `file_explorer = "rnvimr"` in the `whaler` configuration block.
 
 ```lua
 -- Setup rnvimr

--- a/README.md
+++ b/README.md
@@ -230,8 +230,6 @@ Currently the following file explorers are supported out of the box:
 
 ```lua
 -- Setup rnvimr
-vim.g.rnvimr_enable_ex = 1
-
 vim.api.nvim_create_user_command("RnvimrOpen", function(args)
     if #args.fargs == 1 then
        local arg = vim.fn.expand(args.fargs[1])

--- a/README.md
+++ b/README.md
@@ -226,6 +226,23 @@ Currently the following file explorers are supported out of the box:
 - [Oil](https://github.com/stevearc/oil.nvim). Does not require any configuration.
 - [Nvim-Tree](https://github.com/nvim-tree/nvim-tree.lua). To work as intended add `sync_root_with_cwd = true` in the `nvim-tree` setup function.
 - [Telescope-file-browser](https://github.com/nvim-telescope/telescope-file-browser.nvim). Does not require any configuration.
+- [rnvimr](https://github.com/kevinhwang91/rnvimr). To work as intended add the following code to the `rnvimr` settings file and include the `file_explorer = "rnvimr"` in the `whaler` setup function.
+
+```lua
+-- Setup rnvimr
+vim.g.rnvimr_enable_ex = 1
+
+vim.api.nvim_create_user_command("RnvimrOpen", function(args)
+    if #args.fargs == 1 then
+       local arg = vim.fn.expand(args.fargs[1])
+       vim.api.nvim_call_function("rnvimr#open", { arg })
+    else
+       vim.api.nvim_command("RnvimrToggle")
+    end
+end, { nargs = "?" })
+
+vim.api.nvim_set_keymap( "n", "<leader>e", ":RnvimrOpen<CR>", { noremap = true, desc = "Ranger File Explorer" })
+```
 
 
 ## Related projects

--- a/lua/telescope/_extensions/whaler/file_explorer.lua
+++ b/lua/telescope/_extensions/whaler/file_explorer.lua
@@ -61,8 +61,7 @@ M.check_config = function(config)
         return false
     end
 
-	-- stylua: ignore
-    if config["plugin_name"] ~= "netrw" and config["plugin_name"] ~= "rnvimr" then
+    if config["plugin_name"] ~= "netrw" then
         local has_plug, _ = pcall(require, config["plugin_name"])
         if not has_plug then
             log.warn(

--- a/lua/telescope/_extensions/whaler/file_explorer.lua
+++ b/lua/telescope/_extensions/whaler/file_explorer.lua
@@ -61,7 +61,7 @@ M.check_config = function(config)
         return false
     end
 
-    if config["plugin_name"] ~= "netrw" then
+    if config["plugin_name"] ~= "netrw" and config["plugin_name"] ~= "rnvimr" then
         local has_plug, _ = pcall(require, config["plugin_name"])
         if not has_plug then
             log.warn(

--- a/lua/telescope/_extensions/whaler/file_explorer.lua
+++ b/lua/telescope/_extensions/whaler/file_explorer.lua
@@ -14,7 +14,7 @@ local FILEX_ENUM = {
         command = "Explore",
         prefix_dir = " ",
     },
-    --[[ TODO: Does not work very well as it gets out of nvim?? 
+    --[[ TODO: Does not work very well as it gets out of nvim??
     nnn = {
         plugin_name = "nnn",
         command = "NnnPicker",
@@ -44,6 +44,12 @@ local FILEX_ENUM = {
         command = "Telescope file_browser",
         prefix_dir = " path=",
     },
+    rnvimr = {
+        -- Works out of the box.
+        plugin_name = "rnvimr",
+        command = "RnvimrOpen",
+        prefix_dir = " ",
+    },
 }
 
 M.check_config = function(config)
@@ -55,7 +61,8 @@ M.check_config = function(config)
         return false
     end
 
-    if config["plugin_name"] ~= "netrw" then
+	-- stylua: ignore
+    if config["plugin_name"] ~= "netrw" and config["plugin_name"] ~= "rnvimr" then
         local has_plug, _ = pcall(require, config["plugin_name"])
         if not has_plug then
             log.warn(


### PR DESCRIPTION
This commit adds support for the `rnvimr` plugin, allowing users to use the `rnvimr` file explorer within the `whaler` extension of telescope. The following changes were made:
- Added `rnvimr` plugin configuration instructions to the README.
- Included the configuration for integrating the launch command of the `rnvimr` file explorer into the `FILEX_ENUM` table