### PR TITLE
Fixed Typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ return {
         },
         -- Directories to be directly used as projects. No subdirectory lookup.
         oneoff_directories = {
-            { path = "~/.local/share/nvim/lazy", alias = "Neovim Installation"}
+            { path = "~/.local/share/nvim/lazy", alias = "Neovim Installation"},
             { path = "~/.config/", alias = "Config directory"}
         },
 


### PR DESCRIPTION
Noticed a missing comma in the example lazy installation that causes an lsp error.

Users wouldn't really want to directly copy and use those example paths anyway, but still, probably better to clean up the typo